### PR TITLE
escape $query

### DIFF
--- a/ldregistry/templates/navbar.vm
+++ b/ldregistry/templates/navbar.vm
@@ -53,7 +53,7 @@
 
     <form action="$uiroot/text-search" method="get" class="navbar-form navbar-left" role="search">
       <div class="form-group">
-        <input type="search" class="form-control search-query" placeholder="Search" #if($query)value="$query"#end name="query"/>
+        <input type="search" class="form-control search-query" placeholder="Search" #if($query)value="$lib.escapeHtml($query)"#end name="query"/>
       </div>
       <button type="submit" class="btn btn-default">Submit</button>
     </form>

--- a/ldregistry/templates/text-search.vm
+++ b/ldregistry/templates/text-search.vm
@@ -13,7 +13,7 @@
             </tr>
 #end
 
-#set($pageTitle="Search: $query")
+#set($pageTitle="Search: $lib.escapeHtml($query)")
 #parse("header.vm")
 #parse("navbar.vm")
 


### PR DESCRIPTION
fix xss in search

I'm not sure if 
https://github.com/marqh/registry-config-base/blob/f8460ce289232cc36ae49fd0e6f115dfbc71c9f2/ldregistry/templates/text-search.vm#L21
requires a change, so I have not done so.  I thought this might adversely change behaviour