### PR TITLE
Initial OAuth2 Configuration

### DIFF
--- a/ldregistry/config/app.conf
+++ b/ldregistry/config/app.conf
@@ -46,6 +46,9 @@ requestLogger        = com.epimorphics.registry.message.GenericRequestLogger
 requestLogger.logDir = /var/opt/ldregistry/logstore
 # requestLogger.notificationScript = 
 
+# OAuth2 support
+oauth2               = com.epimorphics.registry.webapi.oauth2.OAuth2Service
+
 # Additional configuration paramaters, typically to control UI behaviour
 config               = com.epimorphics.appbase.core.GenericConfig
 #config.suppressPasswordLogin = true
@@ -56,6 +59,7 @@ config.showRegisterAsDatatable = true
 config.registryName  = Test Registry
 config.showStatus = valid
 #config.loginMaster = https://environment.data.gov.uk/registry
+config.oauth2        = $oauth2
 
 # The Registry configuration itself
 registry             = com.epimorphics.registry.core.Registry

--- a/ldregistry/config/oauth2/oauth.conf
+++ b/ldregistry/config/oauth2/oauth.conf
@@ -1,0 +1,2 @@
+ldregistry.usehttps = false
+ldregistry.providers = googleplus

--- a/ldregistry/config/oauth2/provider/googleplus.properties
+++ b/ldregistry/config/oauth2/provider/googleplus.properties
@@ -1,0 +1,9 @@
+name           = googleplus
+label          = Google+
+client.id      = ## your client id
+client.secret  = ## your client secret
+auth.endpoint  = https://accounts.google.com/o/oauth2/auth
+token.endpoint = https://accounts.google.com/o/oauth2/token
+userInfo.endpoint   = https://www.googleapis.com/oauth2/v3/userinfo
+userInfo.key   = profile
+userInfo.name  = name

--- a/ldregistry/templates/login.vm
+++ b/ldregistry/templates/login.vm
@@ -2,15 +2,9 @@
 ##    $return the page to return to (or is that just referrer)
 
 #set($pageTitle="Registry login")
+#set($oauthProviders = $registry.configExtensions.oauth2.config.providers)
 
 #parse("structure/_preamble.vm")
-
-#set($provider=false)
-#foreach($cookie in $request.cookies)
-  #if($cookie.name == "ukgovld-login-provider")
-    #set($provider=$cookie.value)
-  #end
-#end
 
 #if( $registry.configExtensions.loginMaster )
     #set( $lroot = $registry.configExtensions.loginMaster )
@@ -68,16 +62,12 @@
               #if( ! $registry.configExtensions.passwordLoginOnly )
               <div class="row space-above">
                 <div class="col-md-12">
-                  <form class="form-horizontal" action="$lroot/system/security/loginoa" method="post">
-                    #if(!$registry.configExtensions.suppressPasswordLogin)
-                    <p>Or login via a registered Google G+ account</p>
-                    #end
-                    <div class="input-group">
-                      <input type="hidden" name="provider" value="https://accounts.google.com/o/oauth2/auth" />
-                      <input type="hidden" name="return" value="$return" />
-                      <input type="submit" value="login via Google" class="btn btn-primary" type="button" />
-                    </div><!-- /input-group -->
-                  </form>
+                  #if(!$registry.configExtensions.suppressPasswordLogin && !$oauthProviders.isEmpty())
+				    <p>Or log in to a registered account via an OAuth provider.</p>
+				  #end
+				  #foreach($provider in $oauthProviders)
+                    #oauthLogin($provider, $return)
+                  #end
                 </div>
               </div>
               #end
@@ -120,16 +110,12 @@
               #end
               <div class="row space-above">
                 <div class="col-md-12">
-                  <form class="form-horizontal" action="$lroot/system/security/registeroa" method="post">
-                    #if(!$registry.configExtensions.suppressPasswordLogin)
-                    <p>Or authorize via a Google G+ account</p>
-                    #end
-                    <div class="input-group">
-                      <input type="hidden" name="provider" value="https://accounts.google.com/o/oauth2/auth" />
-                      <input type="hidden" name="return" value="$return" />
-                      <input type="submit" value="Create account via Google" class="btn btn-primary" type="button" />
-                    </div>
-                  </form>
+                  #if(!$registry.configExtensions.suppressPasswordLogin && !$oauthProviders.isEmpty())
+                  	<p>Or register via an OAuth provider.</p>
+                  #end
+                  #foreach($provider in $oauthProviders)
+                    #oauthRegister($provider, $return)
+                  #end
                 </div>
               </div>
             </div>

--- a/ldregistry/templates/macros.vm
+++ b/ldregistry/templates/macros.vm
@@ -249,3 +249,23 @@
     #restable($root, "table-condensed table-bordered")
   #end
 #end
+
+#macro(oauthLogin $provider, $return)
+  <form class="form-horizontal" action="$root/system/security/loginoa" method="post">
+	<div class="input-group space-above">
+	  <input type="hidden" name="provider" value="$provider.name" />
+	  <input type="hidden" name="return" value="$return" />
+	  <input type="submit" value="Login via $provider.label" class="btn btn-primary" type="button" />
+	</div><!-- /input-group -->
+  </form>
+#end
+
+#macro(oauthRegister $provider, $return)
+  <form class="form-horizontal" action="$root/system/security/registeroa" method="post">
+	<div class="input-group space-above">
+	  <input type="hidden" name="provider" value="$provider.name" />
+	  <input type="hidden" name="return" value="$return" />
+	  <input type="submit" value="Create account via $provider.label" class="btn btn-primary" type="button" />
+	</div>
+  </form>
+#end


### PR DESCRIPTION
Added an initial OAuth configuration to the base config.

Note that this branch is branched from the `ui-restructure` branch, which has not yet been merged into `master`. In order to enable OAuth registration and login on this branch, you must first change the default setting of `config.passwordLoginOnly` in `app.conf` to `false`.
