### PR TITLE
Multilingual labels

### DIFF
--- a/ldregistry/templates/macros.vm
+++ b/ldregistry/templates/macros.vm
@@ -137,33 +137,52 @@
   #end
 #end
 
-## Display a set of property/value pairs in the RDF browser
-#macro(restable $res $classes)
-  <table class="table $classes">
-##    <thead><tr><th>Property</th><th>Value</th></tr></thead>
+#macro(langtable $values)
+  <table class="langTable">
     <tbody>
-      #foreach($pv in $res.listProperties())
+      #foreach($v in $values)
         <tr>
-          <td class="align-right span2"> <strong title="$pv.getProp().uRI">$pv.getProp().name</strong> </td>
-          <td>
-            #foreach($v in $pv.getValues())
-              #if($v.isList())
-                  (#foreach($e in $v.asList())#resentry($e)#if( $foreach.hasNext ), #end#end)
-              #elseif($v.isAnon())
-                #restable($v)
-              #else
-                #resentry($v)
-              #end
-              #if( $foreach.hasNext )|#end
-              #if( $foreach.count > 100 ) ... #break #end
-            #end
-            <br />
+          <td align="right">
+            <strong>$v.language</strong>
+          </td>
+          <td align="left" class="langValueColumn">
+            #render($v)
           </td>
         </tr>
       #end
     </tbody>
   </table>
+#end
 
+## Display a set of property/value pairs in the RDF browser
+#macro(restable $res $classes)
+  <table class="table $classes">
+    <tbody>
+      #foreach($pv in $res.listProperties())
+        <tr>
+          <td class="align-right span2"> <strong title="$pv.getProp().uRI">$pv.getProp().name</strong> </td>
+          <td>
+            #if($pv.isMultilingual())
+              #langtable($pv.getValues())
+            #else
+              #foreach($v in $pv.getValues())
+                #if($v.isList())
+                    (#foreach($e in $v.asList())#resentry($e)#if( $foreach.hasNext ), #end#end)
+                #elseif($v.isAnon())
+                  #restable($v)
+                #else
+                  #resentry($v)
+                #end
+                #if( $foreach.hasNext )|#end
+                #if( $foreach.count > 100 ) ... #break #end
+              #end
+              <br />
+            #end
+          </td>
+        </tr>
+      #end
+    </tbody>
+  </table>
 #end
 
 ## Conditional row in a metadata table

--- a/ldregistry/ui/assets/css/ui.css
+++ b/ldregistry/ui/assets/css/ui.css
@@ -76,3 +76,7 @@ td.align-right {
 #uriField {
     width: 100%;
 }
+
+.langTable .langValueColumn {
+    padding-left: 5px;
+}


### PR DESCRIPTION

![screenshot 2019-01-21 at 09 34 33](https://user-images.githubusercontent.com/37299842/51483111-31d43e00-1d90-11e9-9e48-15ae4010f1eb.png)
Added a multilingual value table to the item view template for the registry UI.
This feature depends on new functionality added to `lib` in [this commit](https://github.com/epimorphics/lib/commit/067ea1cae7329e354447df74b2e86f1bcc83ff51).

Corresponds to [this branch](https://github.com/UKGovLD/registry-core/pull/100) on `registry-core`.