### PR TITLE
Ensure status dialog goes via correct routing

### DIFF
--- a/ldregistry/templates/actions/_set-status-dialog.vm
+++ b/ldregistry/templates/actions/_set-status-dialog.vm
@@ -15,6 +15,7 @@
         }
         $.ajax(action,{
             type : "POST",
+            contentType : "application/x-www-form-urlencoded; charset=UTF-8",
             success :
               function(data, status, xhr){
                 $("#status-dialog").modal("hide");


### PR DESCRIPTION
This is an earlier fix that was omited from recent changes. Intended to force the right routing in in registry core. Not clear if this is still needed but not harmful.