### PR TITLE
Fix incorrect xss clean of hrefs

### DIFF
--- a/ldregistry/templates/login.vm
+++ b/ldregistry/templates/login.vm
@@ -132,7 +132,7 @@
       <div class="modal-page-footer">
         <div class="row">
           <div class="col-md-offset-10 col-md-1">
-            <a href="#if($return)$lib.reg.xssCleanURI($return)#else$root#end" class="btn">$msg['ui.close']</a>
+            <a href="#if($return)$lib.reg.xssCleanHTMLAtribute($return)#else$root#end" class="btn">$msg['ui.close']</a>
           </div>
         </div>
       </div>

--- a/ldregistry/templates/macros.vm
+++ b/ldregistry/templates/macros.vm
@@ -48,7 +48,7 @@
 #end
 
 ## Determine the href value to use in a link to the given resource, reference URIs go external
-#macro(linkhref $res)#if($res.uRI.startsWith($registry.baseURI))$root$lib.reg.xssCleanURI($res.uRI.substring($registry.baseURI.length()))#else#set($href = $lib.reg.xssCleanURI($res.uRI))#if($href.startsWith("javascript:"))#[[#]]##else$href#end#end#end
+#macro(linkhref $res)#if($res.uRI.startsWith($registry.baseURI))$root$lib.reg.xssCleanHTMLAtribute($res.uRI.substring($registry.baseURI.length()))#else#set($href = $lib.reg.xssCleanHTMLAtribute($res.uRI))#if($href.startsWith("javascript:"))#[[#]]##else$href#end#end#end
 
 ## Determine the href value to use in a link to the given resource, reference URIs go internal
 #macro(linkhrefInt $res)#if($res.uRI.startsWith($registry.baseURI))${root}$res.uRI.substring($registry.baseURI.length())#else${root}/?entity=$lib.pathEncode($res.getURI())#end#end

--- a/ldregistry/templates/registry-compare.vm
+++ b/ldregistry/templates/registry-compare.vm
@@ -10,12 +10,12 @@
 #macro( resultRowValues $item )
   #set( $itemEntity = $item.getPropertyValue("reg:definition").getPropertyValue("reg:entity") )
   <td>
-    <a href="#linkhref($item)" title="$lib.reg.xssCleanURI($item.uRI)" target="_blank">$item.name</a>
+    <a href="#linkhref($item)" title="$lib.reg.xssCleanHTMLAtribute($item.uRI)" target="_blank">$item.name</a>
   </td>
   <td>
     #set( $registerPath = $item.getPropertyValue("reg:register").uRI.substring($registry.baseURI.length()) )
     #set( $registerUri = "$root$registerPath" )
-    <a href="$lib.reg.xssCleanURI($registerUri)" title="$lib.reg.xssCleanURI($registerUri)" target="_blank">$registerPath</a>
+    <a href="$lib.reg.xssCleanHTMLAtribute($registerUri)" title="$lib.reg.xssCleanHTMLAtribute($registerUri)" target="_blank">$registerPath</a>
   </td>
   <td>
     #foreach($ty in $itemEntity.listPropertyValues("rdf:type"))


### PR DESCRIPTION
Addresses: UKGovLD/registry-core#185

The fix for XSS bug UKGovLD/registry-core#181 involved splitting the xss clean operations into different variants for attribute (include href), URI and HTML body cleaning. However, that changed the behaviour of xssCleanURI and that changes needs to be propagated to the templates, primarily the link macro.